### PR TITLE
Fixed 404 error if Teamcity running in suburl path

### DIFF
--- a/brdtcplugin-server/src/main/java/brdtcplugin/BrdBuildPageExtension.java
+++ b/brdtcplugin-server/src/main/java/brdtcplugin/BrdBuildPageExtension.java
@@ -52,6 +52,7 @@ public class BrdBuildPageExtension extends SimplePageExtension {
         }
 
         model.put("urllist", urllist);
+        model.put("baseurl", buildServer.getRootUrl());
     }
 
     private String getArtifactUrl(SBuild build, String artifactFilename) {

--- a/brdtcplugin-server/src/main/resources/buildServerResources/Brd.jsp
+++ b/brdtcplugin-server/src/main/resources/buildServerResources/Brd.jsp
@@ -3,12 +3,11 @@
     taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %><%@
     taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %><%@
     taglib prefix="bs" tagdir="/WEB-INF/tags"
-
 %>
 <jsp:useBean id="urllist" scope="request" type="java.util.ArrayList"/>
-
+<jsp:useBean id="baseurl" scope="request" type="java.lang.String"/>
 <c:forEach items="${urllist}" var="url">
 <c:if test="${not empty url}">
-<iframe src="/repository/download/${url}?redirectSupported=false" allowtransparency="true" onload="this.style.height=(this.contentDocument.body.scrollHeight+45) +'px';" scrolling="no" style="width:100%;border:none;"></iframe>
+<iframe src="${baseurl}repository/download/${url}?redirectSupported=false" allowtransparency="true" onload="this.style.height=(this.contentDocument.body.scrollHeight+45) +'px';" scrolling="no" style="width:100%;border:none;"></iframe>
 </c:if>
 </c:forEach>


### PR DESCRIPTION
In use-case where TeamCity accessed at suburl path was error that iframe pointed at wrong file location.
Fixed it by constructing absolute path for iframe using BuildServer's knowledge of it's RootUrl path.

Should not effectively affect cases when TeamCity running under web server's root but I'm have no means to check it right now